### PR TITLE
Issue #19: Remove User type nested under Weight type

### DIFF
--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -3,7 +3,6 @@ import {
   del as deleteUser,
   update as updateUser,
   getById as user,
-  getByIdRoot as userNested,
   getWhere as users,
 } from './user-resolvers';
 import {
@@ -35,9 +34,6 @@ const resolvers = {
   },
   User: {
     weights: getWeightByUserId,
-  },
-  Weight: {
-    user: userNested,
   },
 };
 

--- a/src/resolvers/user-resolvers.ts
+++ b/src/resolvers/user-resolvers.ts
@@ -32,16 +32,6 @@ const getById: Types.User.GetById = async (_root, args) => {
   }
 };
 
-const getByIdRoot: Types.User.GetByIdRoot = async (root) => {
-  const { userId } = root;
-
-  try {
-    return await UserServices.getById(userId);
-  } catch (error) {
-    throw ErrorUtils.createGraphqlError(error);
-  }
-};
-
 const getWhere: Types.User.GetWhere = async (_root, args) => {
   const { where } = args;
 
@@ -62,4 +52,4 @@ const update: Types.User.Update = async (_root, args) => {
   }
 };
 
-export { create, del, getById, getByIdRoot, getWhere, update };
+export { create, del, getById, getWhere, update };

--- a/src/schema/weight-schema.ts
+++ b/src/schema/weight-schema.ts
@@ -16,7 +16,6 @@ const typeDefs = gql`
     id: ID!
     weight: Float!
     date: Date!
-    user: User!
     userId: ID!
   }
 

--- a/tests/src/resolvers/index.spec.ts
+++ b/tests/src/resolvers/index.spec.ts
@@ -12,7 +12,6 @@ const {
   del: deleteUser,
   update: updateUser,
   getById: user,
-  getByIdRoot: userNested,
   getWhere: users,
 } = UserResolvers as jest.Mocked<typeof UserResolvers>;
 const {
@@ -47,9 +46,6 @@ describe('Resolver Map', () => {
         },
         User: {
           weights: getWeightByUserId,
-        },
-        Weight: {
-          user: userNested,
         },
       }),
     );

--- a/tests/src/resolvers/user-resolvers.spec.ts
+++ b/tests/src/resolvers/user-resolvers.spec.ts
@@ -26,7 +26,6 @@ describe('Given a set of user resolvers', () => {
     args: User.Args,
     input: User.Input | User.UpdateInput,
     id: Uuid,
-    userId: Uuid,
     where: User.Where;
 
   beforeEach(() => {
@@ -201,62 +200,6 @@ describe('Given a set of user resolvers', () => {
       test('Then should try to get a user', () => {
         expect(getByIdService).toHaveBeenCalledTimes(1);
         expect(getByIdService).toHaveBeenCalledWith(id);
-      });
-      test('Then should create a graphql error', () => {
-        expect(createGraphqlError).toHaveBeenCalledTimes(1);
-        expect(createGraphqlError).toHaveBeenCalledWith(creationError);
-      });
-      test('Then should return an error', () => {
-        expect(actualError).toStrictEqual(expectedError);
-      });
-    });
-  });
-  describe('When getting a user by id on root', () => {
-    let root: User.NestedRoot;
-
-    beforeEach(() => {
-      userId = chance.guid();
-      root = {
-        userId,
-      };
-    });
-
-    describe('When successful', () => {
-      let expectedResult: User.User, result: User.User;
-
-      beforeEach(async () => {
-        expectedResult = UserFactories.createRandomUser();
-        getByIdService.mockResolvedValue(expectedResult);
-
-        result = await UserResolvers.getByIdRoot(root, args as null, context);
-      });
-      test('Then should get a user', () => {
-        expect(getByIdService).toHaveBeenCalledTimes(1);
-        expect(getByIdService).toHaveBeenCalledWith(userId);
-      });
-      test('Then should return a user', () => {
-        expect(result).toStrictEqual(expectedResult);
-      });
-    });
-    describe('When unsuccessful', () => {
-      let expectedError: GraphqlError, creationError: Error, actualError: Error;
-
-      beforeEach(async () => {
-        creationError = new Error(chance.string());
-        getByIdService.mockRejectedValue(creationError);
-
-        expectedError = ErrorFactories.createRandomGraphqlError();
-        createGraphqlError.mockReturnValue(expectedError);
-
-        try {
-          await UserResolvers.getByIdRoot(root, args as null, context);
-        } catch (error) {
-          actualError = error;
-        }
-      });
-      test('Then should try to get a user', () => {
-        expect(getByIdService).toHaveBeenCalledTimes(1);
-        expect(getByIdService).toHaveBeenCalledWith(userId);
       });
       test('Then should create a graphql error', () => {
         expect(createGraphqlError).toHaveBeenCalledTimes(1);

--- a/tests/src/schema/weight-schema.spec.ts
+++ b/tests/src/schema/weight-schema.spec.ts
@@ -20,7 +20,6 @@ describe('Given the WeightSchema', () => {
         id: ID!
         weight: Float!
         date: Date!
-        user: User!
         userId: ID!
       }
 


### PR DESCRIPTION
### Description

Remove the user type that is nested under the weight type. There's no use case as of now for this relationship to exist.

### Outcomes

- [x] User is removed from Weight GQL type
- [x] Code powering nested type is removed

### Completes

- [x] Closes #19 
